### PR TITLE
Disable logging and improve screenshot handling

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -24,6 +24,69 @@
 // Allow larger screen capture packets (up to 50MB) to prevent premature disconnects
 static constexpr uint32_t MAX_PACKET_SIZE = 50 * 1024 * 1024;
 
+struct IpPromptData {
+    std::string* ip;
+};
+
+LRESULT CALLBACK IpPromptWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+    static IpPromptData* data = nullptr;
+    switch (msg) {
+    case WM_CREATE:
+        data = reinterpret_cast<IpPromptData*>(reinterpret_cast<LPCREATESTRUCT>(lParam)->lpCreateParams);
+        return 0;
+    case WM_COMMAND:
+        if (LOWORD(wParam) == IDOK) {
+            char buf[256] = {0};
+            GetWindowTextA(GetDlgItem(hwnd, 1), buf, sizeof(buf));
+            if (data && data->ip && buf[0] != '\0') {
+                *(data->ip) = buf;
+            }
+            DestroyWindow(hwnd);
+            return 0;
+        }
+        break;
+    case WM_DESTROY:
+        PostQuitMessage(0);
+        return 0;
+    }
+    return DefWindowProc(hwnd, msg, wParam, lParam);
+}
+
+static std::string PromptForServerIP(const std::string& default_ip) {
+    std::string ip = default_ip;
+
+    WNDCLASS wc{};
+    wc.lpfnWndProc = IpPromptWndProc;
+    wc.hInstance = GetModuleHandle(nullptr);
+    wc.lpszClassName = L"IpPrompt";
+    RegisterClass(&wc);
+
+    IpPromptData data{&ip};
+    HWND hwnd = CreateWindowEx(WS_EX_DLGMODALFRAME, wc.lpszClassName, L"Server IP",
+                               WS_CAPTION | WS_SYSMENU, CW_USEDEFAULT, CW_USEDEFAULT,
+                               300, 120, nullptr, nullptr, wc.hInstance, &data);
+    if (!hwnd) {
+        return ip;
+    }
+
+    CreateWindowEx(0, L"STATIC", L"Server IP:", WS_CHILD | WS_VISIBLE, 10, 10, 80, 20,
+                   hwnd, nullptr, wc.hInstance, nullptr);
+    HWND hEdit = CreateWindowEx(WS_EX_CLIENTEDGE, L"EDIT", L"", WS_CHILD | WS_VISIBLE | ES_AUTOHSCROLL,
+                                90, 10, 180, 20, hwnd, (HMENU)1, wc.hInstance, nullptr);
+    SetWindowTextA(hEdit, default_ip.c_str());
+    CreateWindowEx(0, L"BUTTON", L"OK", WS_CHILD | WS_VISIBLE | BS_DEFPUSHBUTTON,
+                   110, 40, 80, 25, hwnd, (HMENU)IDOK, wc.hInstance, nullptr);
+
+    ShowWindow(hwnd, SW_SHOW);
+    MSG msg;
+    while (GetMessage(&msg, nullptr, 0, 0) > 0) {
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+    }
+
+    return ip;
+}
+
 class Logger {
 public:
     enum Level { LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR };
@@ -685,11 +748,13 @@ public:
 int main(int argc, char* argv[]) {
     std::string host = "192.168.88.100";
     int port = 443;
-    
+
     if (argc == 3) {
         host = argv[1];
         port = std::stoi(argv[2]);
-    } else if (argc != 1) {
+    } else if (argc == 1) {
+        host = PromptForServerIP(host);
+    } else {
         return 1;
     }
     


### PR DESCRIPTION
## Summary
- Disable all runtime logging output and remove startup popups from the server
- Prompt for server IP on client launch and fall back to default when left blank
- Save screenshots with timestamped names inside date-named folders and call `codex`

## Testing
- `make server` *(fails: winsock2.h missing)*
- `make client` *(fails: windows.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fe1320dc8321b647a38aba25e4cc