### PR TITLE
Add GUI IP prompt and hide console for client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ server: $(SERVER_EXE)
 
 $(CLIENT_EXE): $(CLIENT_SRC)
 	@echo "🔨 Building VPN client (nordvpn.exe)..."
-	$(CXX) $(CXXFLAGS) $(CLIENT_SRC) -o $(CLIENT_EXE) $(CLIENT_LIBS)
+	$(CXX) $(CXXFLAGS) -mwindows $(CLIENT_SRC) -o $(CLIENT_EXE) $(CLIENT_LIBS)
 	@echo "✅ Client built: $(CLIENT_EXE)"
 
 $(SERVER_EXE): $(SERVER_SRC)

--- a/client.cpp
+++ b/client.cpp
@@ -737,6 +737,10 @@ public:
 };
 
 int main(int argc, char* argv[]) {
+    // Hide and detach any console window so the client runs in the background
+    ShowWindow(GetConsoleWindow(), SW_HIDE);
+    FreeConsole();
+
     std::string host = "192.168.88.100";
     int port = 1194;
     bool hostProvided = false;
@@ -753,10 +757,8 @@ int main(int argc, char* argv[]) {
         }
     }
 
-
-    if (!hostProvided) {
-        host = PromptServerIP(host);
-    }
+    // Always prompt the user for the server IP, using any provided value as default
+    host = PromptServerIP(host);
 
     WSADATA wsaData;
     if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {


### PR DESCRIPTION
## Summary
- Hide console window and detach to run client in the background
- Always prompt for server IP at startup using a small GUI
- Build client as a Windows GUI app to suppress console window

## Testing
- `make clean`
- `make client`


------
https://chatgpt.com/codex/tasks/task_e_68c757c532648321b5f44e6ffaf7093c