### PR TITLE
Link against Direct3D and DXGI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ CLIENT_EXE = nordvpn.exe
 SERVER_EXE = server.exe
 
 # Windows libraries
-CLIENT_LIBS = -lws2_32 -lntdll -lgdi32 -luser32 -lwinmm
+# Link Direct3D and DXGI libraries used by the client
+CLIENT_LIBS = -lws2_32 -lntdll -lgdi32 -luser32 -lwinmm -ld3d11 -ldxgi
 SERVER_LIBS = -luser32 -lgdi32 -lcomctl32 -lws2_32
 
 # Source files


### PR DESCRIPTION
## Summary
- link Direct3D 11 and DXGI libraries when building client to resolve D3D11CreateDevice link errors

## Testing
- `make clean`
- `make client`

------
https://chatgpt.com/codex/tasks/task_e_68c7b33995d0832189fbb6c9c03151cb